### PR TITLE
Fixed case of single character

### DIFF
--- a/data/na/swagger/1-0-5.yaml
+++ b/data/na/swagger/1-0-5.yaml
@@ -1404,7 +1404,7 @@ definitions:
         type:  number
         format:  double
         description: 'Total amount that Bambora held in a reserve account as of the previous statement period.'
-  statementReport:
+  StatementReport:
     properties:
       data:
         type: array


### PR DESCRIPTION
The dev docs build broke because the definition for the StatementReport previously was "statementReport".