### PR TITLE
cherry pick to test Update EMV_3D_secure.md

### DIFF
--- a/source/docs/guides/EMV_3D_secure.md
+++ b/source/docs/guides/EMV_3D_secure.md
@@ -630,7 +630,6 @@ _In rare cases the issuer can downgrade an authenticated transaction after proce
 |Visa|4532155854421931|Attempted|Frictionless|
 |Visa|4921814859264089|Attempted|Frictionless|
 |MasterCard|5156400512420624|Attempted|Frictionless|
-|MasterCard|5156400512420624|Attempted|Frictionless|
 |MasterCard|5200008932030109|Attempted|Frictionless|
 |MasterCard|5576939757108172|Attempted|Frictionless|
 |Amex|376691390182618|Attempted|Frictionless|


### PR DESCRIPTION
ZOO-789 Dev Portal Update - Remove duplicate test-card from 3DS2 Test-Cards reference. This cherry pick is based on
https://github.com/bambora-na/dev.na.bambora.com/pull/107
